### PR TITLE
chore: exclude emacs backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /dist
 .DS_Store
+*.*~


### PR DESCRIPTION
* exclude `*.*~` files