### PR TITLE
chore: envs, rust stable, trunk with public-url

### DIFF
--- a/.github/workflows/build_and_deploy_to_pages.yml
+++ b/.github/workflows/build_and_deploy_to_pages.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches: ["main"]
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
@@ -15,6 +14,9 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  TRUNK_VERSION: "0.21.13"
+  TAILWIND_VERSION: "4.1.3"
+  PUBLIC_URL: "https://duke-m.github.io/rusty-pi-cake/"
 
 jobs:
   build:
@@ -22,50 +24,61 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Run workspace tests
         run: cargo test
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      # Build with trunk-rs
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-          toolchain: nightly-x86_64-unknown-linux-gnu
+          toolchain: stable-x86_64-unknown-linux-gnu
           components: rust-src
+
       - uses: actions/setup-node@v4
         with:
           node-version: latest
-      - name: NPM tailwind
+
+      - name: Install Tailwind via NPM (optional if you use binary)
         run: npm install -g tailwind@v4 tailwindcss@4
+
       - name: Create ci-tools directory
         run: mkdir ci-tools
-      - name: Get Tailwind via wget
+
+      - name: Download Tailwind binary
         run: |
-          wget -q -O ci-tools/tailwindcss https://github.com/tailwindlabs/tailwindcss/releases/download/v4.1.3/tailwindcss-linux-x64
+          wget -q -O ci-tools/tailwindcss https://github.com/tailwindlabs/tailwindcss/releases/download/v${{ env.TAILWIND_VERSION }}/tailwindcss-linux-x64
           chmod +x ci-tools/tailwindcss
+
       - name: Download and install Trunk binary
         run: |
-          wget -qO- https://github.com/trunk-rs/trunk/releases/download/v0.21.13/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
+          wget -qO- https://github.com/trunk-rs/trunk/releases/download/v${{ env.TRUNK_VERSION }}/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
           mv trunk ci-tools
           chmod +x ci-tools/trunk
+
       - name: Set PATH to ci-tools
         run: echo "PATH=$(pwd)/ci-tools:$PATH" >> $GITHUB_ENV
-      - name: Make sure tools exist
+
+      - name: Ensure tools exist
         run: |
           test -f ci-tools/tailwindcss || (echo "❌ tailwindcss not found!" && exit 1)
           test -f ci-tools/trunk || (echo "❌ trunk not found!" && exit 1)
+
       - name: Build with Trunk
-        run: trunk build --release
+        run: trunk build --release --public-url ${{ env.PUBLIC_URL }}
+
       - name: Check dist exists
         run: test -d dist || (echo "❌ dist/ folder not found!" && exit 1)
+
       - name: Upload static files as artifact
         id: deployment
         uses: actions/upload-pages-artifact@v3
         with:
           path: dist/
 
-  # Deployment job
   deploy:
     environment:
       name: github-pages


### PR DESCRIPTION
- use envs for a better overview of what my needs to be updated
- use rust stable toolchain
- use trunk with public-url to deploy to gh-pages