### PR TITLE
fix: follow best practices

### DIFF
--- a/src/bin/worker.rs
+++ b/src/bin/worker.rs
@@ -74,7 +74,7 @@ fn main() {
                         log!("{}: {}", n, result);
                         // Send intermediate result
                         let progress_response =
-                            WorkerResponse::Result(WorkerResult::new(4.0 * result, n as u64));
+                            WorkerResponse::Result(WorkerResult::new(4.0 * result, n));
                         let js_value = serde_wasm_bindgen::to_value(&progress_response).unwrap();
                         scope_clone.post_message(&js_value).unwrap();
                     }

--- a/src/laborer.rs
+++ b/src/laborer.rs
@@ -83,7 +83,7 @@ impl Laborer {
         let options = WorkerOptions::new();
         // using module workers, see also https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker
         options.set_type(WorkerType::Module);
-        let worker = Worker::new_with_options(&worker_script_url, &options).expect("failed to spawn worker"); 
+        let worker = Worker::new_with_options(worker_script_url, &options).expect("failed to spawn worker"); 
         worker.set_onmessage(Some(onmessage_callback.as_ref().unchecked_ref()));
 
         Self {


### PR DESCRIPTION
- do not use a reference that the compile would deref
- do not cast when not needed (type as type)