### PR TITLE
chore: fix permission issue

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -4,10 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches: ["main"]
-    tags: ["v*"]
-    paths: ["**/Cargo.toml"]
-  pull_request:
-    branches: ["main"]
     paths: ["**/Cargo.toml"]
   schedule:
     - cron: "42 3 * * *"


### PR DESCRIPTION
- Action tries to access a resource in a context that doesn't have the required permissions — especially on pull requests from forks.
- When a pull request originates from a fork, GitHub does not allow access to repository secrets (like secrets.GITHUB_TOKEN) for security reasons.
- Workaround: remove PR
- Also remove v* constraint